### PR TITLE
Fixing quotes being part of the string match

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -4,5 +4,27 @@
         "lineComment": "(",
         // symbols used for start and end a block comment. Remove this entry if your language does not support block comments
         "blockComment": ["(", ")"]
-    }
+    },
+    "autoClosingPairs": [
+        {
+            "open": "(",
+            "close": ")"
+        },
+        {
+            "open": "\"",
+            "close": "\""
+        }
+    ],
+    "surroundingPairs": [
+        [
+            "(",
+            ")"
+        ]
+    ],
+    "brackets": [
+        [
+            "(",
+            ")"
+        ]
+    ]
 }

--- a/syntaxes/rockstar.tmLanguage.json
+++ b/syntaxes/rockstar.tmLanguage.json
@@ -105,18 +105,8 @@
 		"string": {
 			"patterns": [{
 					"begin": "\"",
-					"beginCaptures": {
-						"0": {
-							"name": "string.double.rockstar"
-						}
-					},
 					"end": "\"",
-					"endCaptures": {
-						"0": {
-							"name": "string.double.rockstar"
-						}
-					},
-					"name": "string.double.rockstar"
+					"contentName": "string.double.rockstar"
 				},
 				{
 					"match": "'\\w*'",


### PR DESCRIPTION
I added a second commit adding quotes and brackets to the language configuration